### PR TITLE
Use skeleton loaders on home page

### DIFF
--- a/frontend/web-front/src/features/components/ContentsListSkeleton.tsx
+++ b/frontend/web-front/src/features/components/ContentsListSkeleton.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export default function ContentsListSkeleton(): React.JSX.Element {
+        return (
+                <div className="mb-20 overflow-hidden shadow-md dark:border-gray-700 animate-pulse">
+                        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead>
+                                        <tr>
+                                                <th className="p-3 text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+                                                        日付
+                                                </th>
+                                                <th className="p-3 text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+                                                        日数
+                                                </th>
+                                                <th className="p-3 text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+                                                        時間
+                                                </th>
+                                                <th className="p-3 text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+                                                        種別
+                                                </th>
+                                                <th className="p-3 text-right text-xs font-medium uppercase text-gray-500 dark:text-gray-400"></th>
+                                        </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                                        {Array.from({ length: 3 }).map((_, i) => (
+                                                <tr
+                                                        key={i}
+                                                        className="odd:bg-white even:bg-gray-100 dark:odd:bg-slate-900 dark:even:bg-slate-800"
+                                                >
+                                                        <td className="px-2 py-4">
+                                                                <div className="h-4 w-24 rounded bg-gray-300 dark:bg-gray-600" />
+                                                        </td>
+                                                        <td className="p-4">
+                                                                <div className="h-4 w-8 rounded bg-gray-300 dark:bg-gray-600" />
+                                                        </td>
+                                                        <td className="p-4">
+                                                                <div className="h-4 w-8 rounded bg-gray-300 dark:bg-gray-600" />
+                                                        </td>
+                                                        <td className="p-4">
+                                                                <div className="h-4 w-16 rounded bg-gray-300 dark:bg-gray-600" />
+                                                        </td>
+                                                        <td className="px-2 py-4"></td>
+                                                </tr>
+                                        ))}
+                                </tbody>
+                        </table>
+                </div>
+        );
+}
+

--- a/frontend/web-front/src/features/components/SummarySkeleton.tsx
+++ b/frontend/web-front/src/features/components/SummarySkeleton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function SummarySkeleton(): React.JSX.Element {
+        return (
+                <div className="overflow-hidden rounded-lg border shadow-md dark:border-gray-700 animate-pulse">
+                        <div className="grid grid-cols-3 gap-4 p-6">
+                                <div className="h-6 rounded bg-gray-300 dark:bg-gray-600" />
+                                <div className="h-6 rounded bg-gray-300 dark:bg-gray-600" />
+                                <div className="h-6 rounded bg-gray-300 dark:bg-gray-600" />
+                        </div>
+                        <div className="grid grid-cols-3 gap-4 border-t border-gray-200 p-6 dark:border-gray-700">
+                                <div className="h-6 rounded bg-gray-300 dark:bg-gray-600" />
+                                <div className="h-6 rounded bg-gray-300 dark:bg-gray-600" />
+                                <div className="h-6 rounded bg-gray-300 dark:bg-gray-600" />
+                        </div>
+                </div>
+        );
+}
+

--- a/frontend/web-front/src/pages/_app.tsx
+++ b/frontend/web-front/src/pages/_app.tsx
@@ -1,4 +1,3 @@
-import { PagesProgressBar as ProgressBar } from 'next-nprogress-bar';
 import { ThemeProvider } from 'next-themes';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -44,16 +43,10 @@ export default function App({ Component, pageProps, router }: AppProps) {
 				<title>NenQ -年休管理アプリ-</title>
 			</Head>
 			<CurrentUserContext.Provider value={{ currentUser, setCurrentUser }}>
-				<ThemeProvider attribute="class" defaultTheme="light">
-					<Component {...pageProps} />
-					<ProgressBar
-						height="3px"
-						color="#0eb7c9"
-						options={{ showSpinner: false }}
-						shallowRouting
-					/>
-				</ThemeProvider>
-			</CurrentUserContext.Provider>
-		</>
-	);
+                                <ThemeProvider attribute="class" defaultTheme="light">
+                                        <Component {...pageProps} />
+                                </ThemeProvider>
+                        </CurrentUserContext.Provider>
+                </>
+        );
 }

--- a/frontend/web-front/src/pages/index.tsx
+++ b/frontend/web-front/src/pages/index.tsx
@@ -1,137 +1,133 @@
-import { GetServerSidePropsContext } from 'next';
-import React, { Suspense, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { IoIosLogOut } from 'react-icons/io';
-
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Button from '../components/elements/Button';
 import { ChangeDarkModeButton } from '../components/elements/ChangeDarkModeButton';
 import Section from '../components/layouts/Section';
-import getApi from '../features/api/getApi';
-import getCarryOver from '../features/api/getCarryOver';
-import getSummary from '../features/api/getSummary';
 import ContentsList from '../features/components/ContentsList';
 import CreateModal from '../features/components/CreateModal';
 import DeleteAllModal from '../features/components/DeleteAllModal';
 import LogoutModal from '../features/components/LogoutModal';
 import Summary from '../features/components/Summary';
+import ContentsListSkeleton from '../features/components/ContentsListSkeleton';
+import SummarySkeleton from '../features/components/SummarySkeleton';
+import { clientSideAxios } from '../config/axiosConfig';
 
-type Props = {
-	api: ListData[];
-	summary: SummaryData;
-	carryOver: CarryOverData;
-};
+export default function Home(): React.JSX.Element {
+        const router = useRouter();
+        const [api, setApi] = useState<ListData[]>([]);
+        const [summary, setSummary] = useState<SummaryData | null>(null);
+        const [carryOver, setCarryOver] = useState<CarryOverData | null>(null);
+        const [isLoading, setIsLoading] = useState(true);
+        const [logoutOpen, setLogoutOpen] = useState(false);
+        const [createOpen, setCreateOpen] = useState(false);
+        const [deleteAllOpen, setDeleteAllOpen] = useState(false);
+        const cancelButtonRef = useRef(null);
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-	const access_token = context.req.cookies['access_token'];
+        useEffect(() => {
+                const fetchData = async () => {
+                        try {
+                                const [apiRes, summaryRes, carryOverRes] = await Promise.all([
+                                        clientSideAxios.get('/api/list'),
+                                        clientSideAxios.get('/api/summary'),
+                                        clientSideAxios.get('/api/carryover'),
+                                ]);
+                                setApi(apiRes.data as ListData[]);
+                                setSummary(summaryRes.data as SummaryData);
+                                setCarryOver(carryOverRes.data as CarryOverData);
+                        } catch {
+                                router.push('/login');
+                        } finally {
+                                setIsLoading(false);
+                        }
+                };
+                fetchData();
+        }, [router]);
 
-	const apiData = await getApi(access_token);
-
-	const summaryData = await getSummary(access_token);
-
-	const carryOverData = await getCarryOver(access_token);
-
-	if (!apiData || !summaryData || !carryOverData) {
-		return {
-			redirect: {
-				permanent: false,
-				destination: '/login',
-			},
-		};
-	}
-	return {
-		props: { api: apiData, summary: summaryData, carryOver: carryOverData },
-	};
+        return (
+                <>
+                        <Head>
+                                <title>ホーム</title>
+                                <meta name="description" content="トップページ説明" />
+                        </Head>
+                        <div>
+                                <div className="mb-4 bg-white px-6 py-3 dark:bg-gray-700">
+                                        <div className="flex items-center justify-between">
+                                                <div className="text-3xl">
+                                                        NenQ <span className="text-sm">ー年休管理アプリー</span>
+                                                </div>
+                                                <div className="flex gap-3 px-2">
+                                                        <div>
+                                                                <ChangeDarkModeButton />
+                                                        </div>
+                                                        <div>
+                                                                <button type="submit" onClick={() => setLogoutOpen(true)}>
+                                                                        <IoIosLogOut size="2em" />
+                                                                </button>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                                <Section>
+                                        <p className="mb-2 px-2">取得状況</p>
+                                        {isLoading || !summary || !carryOver ? (
+                                                <SummarySkeleton />
+                                        ) : (
+                                                <Summary summaryData={summary} carryOverData={carryOver} />
+                                        )}
+                                        <br />
+                                        <hr className="border-gray-300" />
+                                        <br />
+                                        <div className="flex justify-between">
+                                                <p className="mb-2 px-2">年休一覧</p>
+                                                <div className="flex gap-4">
+                                                        <Button
+                                                                rounded
+                                                                className="hidden bg-rose-500 px-4 py-2 text-sm font-bold text-white shadow-lg hover:bg-rose-800 dark:bg-rose-700 dark:hover:bg-rose-800 sm:block"
+                                                                onClick={() => setCreateOpen(true)}
+                                                        >
+                                                                ＋　追加
+                                                        </Button>
+                                                        <button
+                                                                className="px-4 py-2 text-sm text-gray-400 hover:text-gray-500"
+                                                                onClick={() => setDeleteAllOpen(true)}
+                                                        >
+                                                                ✗　全削除
+                                                        </button>
+                                                </div>
+                                        </div>
+                                        {isLoading ? (
+                                                <ContentsListSkeleton />
+                                        ) : (
+                                                <ContentsList data={api} />
+                                        )}
+                                </Section>
+                                <LogoutModal
+                                        logoutOpen={logoutOpen}
+                                        setLogoutOpen={setLogoutOpen}
+                                        cancelButtonRef={cancelButtonRef}
+                                />
+                                <CreateModal
+                                        createOpen={createOpen}
+                                        setCreateOpen={setCreateOpen}
+                                        cancelButtonRef={cancelButtonRef}
+                                />
+                                <DeleteAllModal
+                                        deleteAllOpen={deleteAllOpen}
+                                        setDeleteAllOpen={setDeleteAllOpen}
+                                        cancelButtonRef={cancelButtonRef}
+                                />
+                                <div>
+                                        <Button
+                                                className="fixed bottom-5 right-5 block rounded-full bg-rose-500 px-4 py-2 text-lg font-bold text-white shadow-lg hover:bg-rose-800 dark:bg-rose-700 dark:hover:bg-rose-800 sm:hidden"
+                                                onClick={() => setCreateOpen(true)}
+                                        >
+                                                ＋
+                                        </Button>
+                                </div>
+                        </div>
+                </>
+        );
 }
 
-export default function Home({
-	api,
-	summary,
-	carryOver,
-}: Props): React.JSX.Element {
-	const [logoutOpen, setLogoutOpen] = useState(false);
-
-	const [createOpen, setCreateOpen] = useState(false);
-
-	const [deleteAllOpen, setDeleteAllOpen] = useState(false);
-
-	const cancelButtonRef = useRef(null);
-
-	return (
-		<>
-			<Head>
-				<title>ホーム</title>
-				<meta name="description" content="トップページ説明" />
-			</Head>
-			<div>
-				<div className="mb-4 bg-white px-6 py-3 dark:bg-gray-700">
-					<div className="flex items-center justify-between">
-						<div className="text-3xl">
-							NenQ <span className="text-sm">ー年休管理アプリー</span>
-						</div>
-						<div className="flex gap-3 px-2">
-							<div>
-								<ChangeDarkModeButton />
-							</div>
-							<div>
-								<button type="submit" onClick={() => setLogoutOpen(true)}>
-									<IoIosLogOut size="2em" />
-								</button>
-							</div>
-						</div>
-					</div>
-				</div>
-				<Section>
-					<p className="mb-2 px-2">取得状況</p>
-					<Suspense fallback="<div>loading...</div>">
-						<Summary summaryData={summary} carryOverData={carryOver} />
-					</Suspense>
-					<br />
-					<hr className="border-gray-300" />
-					<br />
-					<div className="flex justify-between">
-						<p className="mb-2 px-2">年休一覧</p>
-						<div className="flex gap-4">
-							<Button
-								rounded
-								className="hidden bg-rose-500 px-4 py-2 text-sm font-bold text-white shadow-lg hover:bg-rose-800 dark:bg-rose-700 dark:hover:bg-rose-800 sm:block"
-								onClick={() => setCreateOpen(true)}
-							>
-								＋　追加
-							</Button>
-							<button
-								className="px-4 py-2 text-sm text-gray-400 hover:text-gray-500"
-								onClick={() => setDeleteAllOpen(true)}
-							>
-								✗　全削除
-							</button>
-						</div>
-					</div>
-					<ContentsList data={api} />
-				</Section>
-				<LogoutModal
-					logoutOpen={logoutOpen}
-					setLogoutOpen={setLogoutOpen}
-					cancelButtonRef={cancelButtonRef}
-				/>
-				<CreateModal
-					createOpen={createOpen}
-					setCreateOpen={setCreateOpen}
-					cancelButtonRef={cancelButtonRef}
-				/>
-				<DeleteAllModal
-					deleteAllOpen={deleteAllOpen}
-					setDeleteAllOpen={setDeleteAllOpen}
-					cancelButtonRef={cancelButtonRef}
-				/>
-				<div>
-					<Button
-						className="fixed bottom-5 right-5 block rounded-full bg-rose-500 px-4 py-2 text-lg font-bold text-white shadow-lg hover:bg-rose-800 dark:bg-rose-700 dark:hover:bg-rose-800 sm:hidden"
-						onClick={() => setCreateOpen(true)}
-					>
-						＋
-					</Button>
-				</div>
-			</div>
-		</>
-	);
-}


### PR DESCRIPTION
## Summary
- remove progress bar
- fetch home data on client and show skeletons during load

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890534330b0832d9b9df64944968ea1