### PR TITLE
Add backend test fixture for PaidHolidays data

### DIFF
--- a/backend/web-back/paidholidays/fixtures/paidholidays_test_data.json
+++ b/backend/web-back/paidholidays/fixtures/paidholidays_test_data.json
@@ -1,0 +1,274 @@
+[
+  {
+    "model": "users.user",
+    "pk": "11111111-1111-1111-1111-111111111111",
+    "fields": {
+      "username": "testuser",
+      "email": "testuser@example.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2024-01-01T00:00:00",
+      "password": "pbkdf2_sha256$600000$HzDPHdFoP8Xe3ifrTAvF10$r/yJYsxhv0IbeRRLDi9mSMT3H69kIa8RX+VsFbPEnwQ="
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 1,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-01",
+      "end_date": "2024-01-01",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-1"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 2,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-02",
+      "end_date": "2024-01-02",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-2"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 3,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-03",
+      "end_date": "2024-01-03",
+      "date": 1,
+      "hour": 0,
+      "text": "早退",
+      "slug": "entry-3"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 4,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-04",
+      "end_date": "2024-01-04",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-4"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 5,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-05",
+      "end_date": "2024-01-05",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-5"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 6,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-06",
+      "end_date": "2024-01-06",
+      "date": 1,
+      "hour": 0,
+      "text": "早退",
+      "slug": "entry-6"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 7,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-07",
+      "end_date": "2024-01-07",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-7"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 8,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-08",
+      "end_date": "2024-01-08",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-8"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 9,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-09",
+      "end_date": "2024-01-09",
+      "date": 1,
+      "hour": 0,
+      "text": "早退",
+      "slug": "entry-9"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 10,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-10",
+      "end_date": "2024-01-10",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-10"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 11,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-11",
+      "end_date": "2024-01-11",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-11"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 12,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-12",
+      "end_date": "2024-01-12",
+      "date": 1,
+      "hour": 0,
+      "text": "早退",
+      "slug": "entry-12"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 13,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-13",
+      "end_date": "2024-01-13",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-13"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 14,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-14",
+      "end_date": "2024-01-14",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-14"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 15,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-15",
+      "end_date": "2024-01-15",
+      "date": 1,
+      "hour": 0,
+      "text": "早退",
+      "slug": "entry-15"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 16,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-16",
+      "end_date": "2024-01-16",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-16"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 17,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-17",
+      "end_date": "2024-01-17",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-17"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 18,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-18",
+      "end_date": "2024-01-18",
+      "date": 1,
+      "hour": 0,
+      "text": "早退",
+      "slug": "entry-18"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 19,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-19",
+      "end_date": "2024-01-19",
+      "date": 1,
+      "hour": 0,
+      "text": "休暇",
+      "slug": "entry-19"
+    }
+  },
+  {
+    "model": "paidholidays.paidholidays",
+    "pk": 20,
+    "fields": {
+      "user": "11111111-1111-1111-1111-111111111111",
+      "start_date": "2024-01-20",
+      "end_date": "2024-01-20",
+      "date": 1,
+      "hour": 0,
+      "text": "遅刻",
+      "slug": "entry-20"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add sample fixture with user and 20 PaidHolidays records

## Testing
- `python manage.py test` *(fails: Name or service not known for PostgreSQL host `db`)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b245a90832d8070edadfe8a1b05